### PR TITLE
Changes to loop syntax

### DIFF
--- a/crates/crunch-parser/src/parser/stmt.rs
+++ b/crates/crunch-parser/src/parser/stmt.rs
@@ -37,13 +37,18 @@ pub enum Statement<'expr, 'stmt> {
         condition: Expr<'expr>,
         body: Vec<Stmt<'stmt, 'expr>>,
         then: Option<Vec<Stmt<'stmt, 'expr>>>,
+        else_clause: Option<Vec<Stmt<'stmt, 'expr>>>,
     },
-    Loop(Vec<Stmt<'stmt, 'expr>>),
+    Loop {
+    	body: Vec<Stmt<'stmt, 'expr>>,
+    	else_clause: Option<Vec<Stmt<'stmt, 'expr>>>,
+	},
     For {
         var: Expr<'expr>,
         condition: Expr<'expr>,
         body: Vec<Stmt<'stmt, 'expr>>,
         then: Option<Vec<Stmt<'stmt, 'expr>>>,
+        else_clause: Option<Vec<Stmt<'stmt, 'expr>>>,
     },
     Match {
         var: Expr<'expr>,
@@ -341,6 +346,8 @@ impl<'src, 'expr, 'stmt> Parser<'src, 'expr, 'stmt> {
         let body = self.statements(&[TokenType::End, TokenType::Then], 10)?;
 
         let then = self.then_stmt()?;
+        
+        let else_clause = self.else_stmt()?;
 
         self.eat(TokenType::End, [TokenType::Newline])?;
 
@@ -348,6 +355,7 @@ impl<'src, 'expr, 'stmt> Parser<'src, 'expr, 'stmt> {
             condition,
             body,
             then,
+            else_clause
         });
 
         Ok(stmt)
@@ -359,10 +367,12 @@ impl<'src, 'expr, 'stmt> Parser<'src, 'expr, 'stmt> {
         self.eat(TokenType::Newline, [])?;
 
         let body = self.statements(&[TokenType::End, TokenType::Then], 10)?;
+        
+        let else_clause = self.else_stmt()?;
 
         self.eat(TokenType::End, [TokenType::Newline])?;
 
-        let stmt = self.stmt_arena.store(Statement::Loop(body));
+        let stmt = self.stmt_arena.store(Statement::Loop { body, else_clause });
 
         Ok(stmt)
     }
@@ -377,11 +387,13 @@ impl<'src, 'expr, 'stmt> Parser<'src, 'expr, 'stmt> {
 
         let body = self.statements(&[TokenType::End, TokenType::Then], 10)?;
         let then = self.then_stmt()?;
+        let else_clause = self.else_stmt()?;
         let stmt = self.stmt_arena.store(Statement::For {
             var,
             condition,
             body,
             then,
+            else_clause
         });
 
         Ok(stmt)
@@ -393,9 +405,23 @@ impl<'src, 'expr, 'stmt> Parser<'src, 'expr, 'stmt> {
             self.eat(TokenType::Then, [TokenType::Newline])?;
             self.eat(TokenType::Newline, [])?;
 
-            let then = self.statements(&[TokenType::End, TokenType::Then], 3)?;
+            let then = self.statements(&[TokenType::End, TokenType::Else], 3)?;
 
             Ok(Some(then))
+        } else {
+            Ok(None)
+        }
+    }
+
+    #[recursion_guard]
+    fn else_stmt(&mut self) -> ParseResult<Option<Vec<Stmt<'stmt, 'expr>>>> {
+        if self.peek()?.ty() == TokenType::Else {
+            self.eat(TokenType::Else, [TokenType::Newline])?;
+            self.eat(TokenType::Newline, [])?;
+
+            let else_clause = self.statements(&[TokenType::End], 3)?;
+
+            Ok(Some(else_clause))
         } else {
             Ok(None)
         }

--- a/crates/crunch-parser/src/parser/stmt.rs
+++ b/crates/crunch-parser/src/parser/stmt.rs
@@ -40,9 +40,9 @@ pub enum Statement<'expr, 'stmt> {
         else_clause: Option<Vec<Stmt<'stmt, 'expr>>>,
     },
     Loop {
-    	body: Vec<Stmt<'stmt, 'expr>>,
-    	else_clause: Option<Vec<Stmt<'stmt, 'expr>>>,
-	},
+        body: Vec<Stmt<'stmt, 'expr>>,
+        else_clause: Option<Vec<Stmt<'stmt, 'expr>>>,
+    },
     For {
         var: Expr<'expr>,
         condition: Expr<'expr>,
@@ -346,7 +346,7 @@ impl<'src, 'expr, 'stmt> Parser<'src, 'expr, 'stmt> {
         let body = self.statements(&[TokenType::End, TokenType::Then], 10)?;
 
         let then = self.then_stmt()?;
-        
+
         let else_clause = self.else_stmt()?;
 
         self.eat(TokenType::End, [TokenType::Newline])?;
@@ -355,7 +355,7 @@ impl<'src, 'expr, 'stmt> Parser<'src, 'expr, 'stmt> {
             condition,
             body,
             then,
-            else_clause
+            else_clause,
         });
 
         Ok(stmt)
@@ -367,7 +367,7 @@ impl<'src, 'expr, 'stmt> Parser<'src, 'expr, 'stmt> {
         self.eat(TokenType::Newline, [])?;
 
         let body = self.statements(&[TokenType::End, TokenType::Then], 10)?;
-        
+
         let else_clause = self.else_stmt()?;
 
         self.eat(TokenType::End, [TokenType::Newline])?;
@@ -393,7 +393,7 @@ impl<'src, 'expr, 'stmt> Parser<'src, 'expr, 'stmt> {
             condition,
             body,
             then,
-            else_clause
+            else_clause,
         });
 
         Ok(stmt)

--- a/crates/crunch-parser/src/parser/stmt.rs
+++ b/crates/crunch-parser/src/parser/stmt.rs
@@ -38,10 +38,7 @@ pub enum Statement<'expr, 'stmt> {
         body: Vec<Stmt<'stmt, 'expr>>,
         then: Option<Vec<Stmt<'stmt, 'expr>>>,
     },
-    Loop {
-        body: Vec<Stmt<'stmt, 'expr>>,
-        then: Option<Vec<Stmt<'stmt, 'expr>>>,
-    },
+    Loop(Vec<Stmt<'stmt, 'expr>>),
     For {
         var: Expr<'expr>,
         condition: Expr<'expr>,
@@ -363,11 +360,9 @@ impl<'src, 'expr, 'stmt> Parser<'src, 'expr, 'stmt> {
 
         let body = self.statements(&[TokenType::End, TokenType::Then], 10)?;
 
-        let then = self.then_stmt()?;
-
         self.eat(TokenType::End, [TokenType::Newline])?;
 
-        let stmt = self.stmt_arena.store(Statement::Loop { body, then });
+        let stmt = self.stmt_arena.store(Statement::Loop(body));
 
         Ok(stmt)
     }

--- a/crates/crunch-parser/src/parser/tests.rs
+++ b/crates/crunch-parser/src/parser/tests.rs
@@ -535,7 +535,7 @@ fn loop_stmt() {
     stmt_eq!(
         "loop\n    \
             println(true)\n\
-        else\n    \
+        then\n    \
             println(false)\n\
         end\n"
     );
@@ -635,15 +635,14 @@ fn extend_block() {
 
 #[test]
 fn loop_follows_if() {
-    let expected = "Function((data:(decorators:[],attrs:[(data:Visibility(FileLocal),loc:Concrete(span:(start:9,end:19),\
-        file:(0)))],name:(key:1),args:[],returns:(data:Infer,loc:Concrete(span:(start:9,end:19),file:(0))),body:[If(condition:\
-        Comparison(Variable((key:2)),Equal,Literal(String(([(72),(101),(108),(108),(111)])))),body:[Expression(FunctionCall(\
-        caller:Variable((key:3)),arguments:[Literal(String(([(89),(111),(117),(32),(115),(97),(105),(100),(32),(104),(101),(108),\
-        (108),(111)])))]))],clauses:[],else_clause:Some([Expression(FunctionCall(caller:Variable((key:3)),arguments:[Literal(String\
-        (([(89),(111),(117),(32),(100),(105),(100),(110),(39),(116),(32),(115),(97),(121),(32),(104),(101),(108),(108),(111),(32),\
-        (58),(40)])))]))])),Loop(body:[Expression(FunctionCall(caller:Variable((key:3)),arguments:[Literal(String(([(79),(118),(101),\
-        (114),(32),(97),(110),(100),(32),(111),(118),(101),(114),(32),(97),(103),(97),(105),(110)])))]))],then:None)]),loc:Concrete(span\
-        :(start:9,end:272),file:(0))))";
+    let expected = "Function((data:(decorators:[],attrs:[(data:Visibility(FileLocal),loc:Concrete(span:(start:9,end:19,),\
+        file:(0),),),],name:(key:1,),args:[],returns:(data:Infer,loc:Concrete(span:(start:9,end:19,),file:(0),),),body:[If(condition:\
+        Comparison(Variable((key:2,)),Equal,Literal(String(([(72),(101),(108),(108),(111),]))),),body:[Expression(FunctionCall(caller:\
+        Variable((key:3,)),arguments:[Literal(String(([(89),(111),(117),(32),(115),(97),(105),(100),(32),(104),(101),(108),(108),(111),\
+        ]))),],)),],clauses:[],else_clause:Some([Expression(FunctionCall(caller:Variable((key:3,)),arguments:[Literal(String(([(89),(111),\
+        (117),(32),(100),(105),(100),(110),(39),(116),(32),(115),(97),(121),(32),(104),(101),(108),(108),(111),(32),(58),(40),]))),],)),]),\
+        ),Loop(body:[Expression(FunctionCall(caller:Variable((key:3,)),arguments:[Literal(String(([(79),(118),(101),(114),(32),(97),(110),(100),\
+        (32),(111),(118),(101),(114),(32),(97),(103),(97),(105),(110),]))),],)),],then:None,),],),loc:Concrete(span:(start:9,end:272,),file:(0),),))";
     let src = "
         fn test()
             if greeting == \"Hello\"

--- a/crates/crunch-parser/src/parser/tests.rs
+++ b/crates/crunch-parser/src/parser/tests.rs
@@ -535,7 +535,7 @@ fn loop_stmt() {
     stmt_eq!(
         "loop\n    \
             println(true)\n\
-        then\n    \
+        else\n    \
             println(false)\n\
         end\n"
     );

--- a/crates/crunch-parser/src/pretty_printer.rs
+++ b/crates/crunch-parser/src/pretty_printer.rs
@@ -752,7 +752,7 @@ impl<'expr, 'stmt> PrettyPrinter {
                 }
             }
 
-            Statement::Loop(body) => {
+            Statement::Loop { body, else_clause } => {
                 writeln!(f, "loop")?;
 
                 self.indent_level += 1;
@@ -760,6 +760,17 @@ impl<'expr, 'stmt> PrettyPrinter {
                     self.print_stmt(f, stmt)?
                 }
                 self.indent_level -= 1;
+                
+                if let Some(else_clause) = else_clause {
+                     self.print_indent(f)?;
+                     writeln!(f, "else")?;
+                     
+                     self.indent_level += 1;
+                     for stmt in else_clause {
+                         self.print_stmt(f, stmt)?
+                     }
+                     self.indent_level -= 1;
+                }
 
                 self.print_indent(f)?;
                 writeln!(f, "end")
@@ -769,6 +780,7 @@ impl<'expr, 'stmt> PrettyPrinter {
                 condition,
                 body,
                 then,
+                else_clause,
             } => {
                 write!(f, "while ")?;
                 self.print_expr(f, condition)?;
@@ -790,6 +802,17 @@ impl<'expr, 'stmt> PrettyPrinter {
                     }
                     self.indent_level -= 1;
                 }
+                
+                if let Some(else_clause) = else_clause {
+                     self.print_indent(f)?;
+                     writeln!(f, "else")?;
+                     
+                     self.indent_level += 1;
+                     for stmt in else_clause {
+                         self.print_stmt(f, stmt)?
+                     }
+                     self.indent_level -= 1;
+                }
 
                 self.print_indent(f)?;
                 writeln!(f, "end")
@@ -800,6 +823,7 @@ impl<'expr, 'stmt> PrettyPrinter {
                 condition,
                 body,
                 then,
+                else_clause,
             } => {
                 write!(f, "for ")?;
                 self.print_expr(f, var)?;
@@ -822,6 +846,17 @@ impl<'expr, 'stmt> PrettyPrinter {
                         self.print_stmt(f, stmt)?
                     }
                     self.indent_level -= 1;
+                }
+                
+                if let Some(else_clause) = else_clause {
+                     self.print_indent(f)?;
+                     writeln!(f, "else")?;
+                     
+                     self.indent_level += 1;
+                     for stmt in else_clause {
+                         self.print_stmt(f, stmt)?
+                     }
+                     self.indent_level -= 1;
                 }
 
                 self.print_indent(f)?;

--- a/crates/crunch-parser/src/pretty_printer.rs
+++ b/crates/crunch-parser/src/pretty_printer.rs
@@ -60,11 +60,11 @@ impl<'expr, 'stmt> PrettyPrinter {
         }: &ExtendBlock,
     ) -> Result {
         self.print_indent(f)?;
-        write!(f, "extend ")?;
+        f.write_str("extend ")?;
         self.print_ty(f, target)?;
 
         if let Some(extender) = extender {
-            write!(f, " with ")?;
+            f.write_str(" with ")?;
             self.print_ty(f, extender)?;
         }
         writeln!(f)?;
@@ -98,9 +98,9 @@ impl<'expr, 'stmt> PrettyPrinter {
             self.print_attr(f, *attr.data())?;
         }
 
-        write!(f, "alias ")?;
+        f.write_str("alias ")?;
         self.print_ty(f, alias)?;
-        write!(f, " = ")?;
+        f.write_str(" = ")?;
         self.print_ty(f, actual)?;
         writeln!(f)
     }
@@ -126,10 +126,10 @@ impl<'expr, 'stmt> PrettyPrinter {
         )?;
 
         match exposes {
-            ImportExposure::All => write!(f, " exposing *")?,
+            ImportExposure::All => f.write_str(" exposing *")?,
             ImportExposure::None(name) => write!(f, " as {}", self.interner.resolve(name.data()))?,
             ImportExposure::Members(members) => {
-                write!(f, " exposing ")?;
+                f.write_str(" exposing ")?;
 
                 for (i, member) in members.iter().enumerate() {
                     write!(f, "{}", self.interner.resolve(&member.data().0))?;
@@ -139,7 +139,7 @@ impl<'expr, 'stmt> PrettyPrinter {
                     }
 
                     if i != members.len() - 1 {
-                        write!(f, ", ")?;
+                        f.write_str(", ")?;
                     }
                 }
             }
@@ -172,15 +172,15 @@ impl<'expr, 'stmt> PrettyPrinter {
         write!(f, "trait {}", self.interner.resolve(name))?;
 
         if !generics.is_empty() {
-            write!(f, "[")?;
+            f.write_str("[")?;
             for (i, gen) in generics.iter().enumerate() {
                 self.print_ty(f, gen.data())?;
 
                 if i != generics.len() - 1 {
-                    write!(f, ", ")?;
+                    f.write_str(", ")?;
                 }
             }
-            write!(f, "]")?;
+            f.write_str("]")?;
         }
         writeln!(f)?;
 
@@ -217,14 +217,14 @@ impl<'expr, 'stmt> PrettyPrinter {
         write!(f, "enum {}", self.interner.resolve(name))?;
 
         if !generics.is_empty() {
-            write!(f, "[")?;
+            f.write_str("[")?;
             for (i, gen) in generics.iter().enumerate() {
                 self.print_ty(f, gen.data())?;
                 if i != generics.len() - 1 {
-                    write!(f, ", ")?;
+                    f.write_str(", ")?;
                 }
             }
-            write!(f, "]")?;
+            f.write_str("]")?;
         }
         writeln!(f)?;
 
@@ -255,7 +255,7 @@ impl<'expr, 'stmt> PrettyPrinter {
                         self.print_ty(f, ty.data())?;
 
                         if i != elements.len() - 1 {
-                            write!(f, ", ")?;
+                            f.write_str(", ")?;
                         }
                     }
                     writeln!(f, ")")?;
@@ -291,15 +291,15 @@ impl<'expr, 'stmt> PrettyPrinter {
         write!(f, "type {}", self.interner.resolve(name))?;
 
         if !generics.is_empty() {
-            write!(f, "[")?;
+            f.write_str("[")?;
             for (i, gen) in generics.iter().enumerate() {
                 self.print_ty(f, gen.data())?;
 
                 if i != generics.len() - 1 {
-                    write!(f, ", ")?;
+                    f.write_str(", ")?;
                 }
             }
-            write!(f, "]")?;
+            f.write_str("]")?;
         }
         writeln!(f)?;
 
@@ -357,7 +357,7 @@ impl<'expr, 'stmt> PrettyPrinter {
         write!(f, "fn {}", self.interner.resolve(name))?;
 
         if !args.is_empty() {
-            write!(f, "(")?;
+            f.write_str("(")?;
 
             let args = args
                 .iter()
@@ -375,10 +375,10 @@ impl<'expr, 'stmt> PrettyPrinter {
                 .join(", ");
             write!(f, "{})", args)?;
         } else {
-            write!(f, "()")?;
+            f.write_str("()")?;
         }
 
-        write!(f, " -> ")?;
+        f.write_str(" -> ")?;
         self.print_ty(f, returns.data())?;
         writeln!(f)?;
 
@@ -401,10 +401,10 @@ impl<'expr, 'stmt> PrettyPrinter {
                 self.print_expr(f, arg)?;
 
                 if i != dec.args.len() - 1 {
-                    write!(f, ", ")?;
+                    f.write_str(", ")?;
                 }
             }
-            write!(f, ")")
+            f.write_str(")")
         } else {
             write!(f, "@{}", self.interner.resolve(&dec.name.data()))
         }
@@ -416,9 +416,9 @@ impl<'expr, 'stmt> PrettyPrinter {
 
             Expression::UnaryExpr(op, expr) => {
                 match op {
-                    UnaryOperand::Positive => write!(f, "+"),
-                    UnaryOperand::Negative => write!(f, "-"),
-                    UnaryOperand::Not => write!(f, "!"),
+                    UnaryOperand::Positive => f.write_str("+"),
+                    UnaryOperand::Negative => f.write_str("-"),
+                    UnaryOperand::Not => f.write_str("!"),
                 }?;
 
                 self.print_expr(f, expr)
@@ -452,34 +452,34 @@ impl<'expr, 'stmt> PrettyPrinter {
                 false_arm,
             } => {
                 self.print_expr(f, true_arm)?;
-                write!(f, " if ")?;
+                f.write_str(" if ")?;
                 self.print_expr(f, condition)?;
-                write!(f, " else ")?;
+                f.write_str(" else ")?;
                 self.print_expr(f, false_arm)
             }
 
             Expression::Parenthesised(expr) => {
-                write!(f, "(")?;
+                f.write_str("(")?;
                 self.print_expr(f, expr)?;
-                write!(f, ")")
+                f.write_str(")")
             }
 
             Expression::FunctionCall { caller, arguments } => {
                 self.print_expr(f, caller)?;
-                write!(f, "(")?;
+                f.write_str("(")?;
                 for (i, arg) in arguments.iter().enumerate() {
                     self.print_expr(f, arg)?;
 
                     if i != arguments.len() - 1 {
-                        write!(f, ", ")?;
+                        f.write_str(", ")?;
                     }
                 }
-                write!(f, ")")
+                f.write_str(")")
             }
 
             Expression::MemberFunctionCall { member, function } => {
                 self.print_expr(f, member)?;
-                write!(f, ".")?;
+                f.write_str(".")?;
                 self.print_expr(f, function)
             }
 
@@ -488,51 +488,51 @@ impl<'expr, 'stmt> PrettyPrinter {
             Expression::Comparison(left, comp, right) => {
                 self.print_expr(f, left)?;
                 match comp {
-                    ComparisonOperand::Greater => write!(f, " > "),
-                    ComparisonOperand::Less => write!(f, " < "),
-                    ComparisonOperand::GreaterEqual => write!(f, " >= "),
-                    ComparisonOperand::LessEqual => write!(f, " <= "),
-                    ComparisonOperand::Equal => write!(f, " == "),
-                    ComparisonOperand::NotEqual => write!(f, " != "),
+                    ComparisonOperand::Greater => f.write_str(" > "),
+                    ComparisonOperand::Less => f.write_str(" < "),
+                    ComparisonOperand::GreaterEqual => f.write_str(" >= "),
+                    ComparisonOperand::LessEqual => f.write_str(" <= "),
+                    ComparisonOperand::Equal => f.write_str(" == "),
+                    ComparisonOperand::NotEqual => f.write_str(" != "),
                 }?;
                 self.print_expr(f, right)
             }
 
             Expression::IndexArray { array, index } => {
                 self.print_expr(f, array)?;
-                write!(f, "[")?;
+                f.write_str("[")?;
                 self.print_expr(f, index)?;
-                write!(f, "]")
+                f.write_str("]")
             }
 
             Expression::Array(arr) => {
-                write!(f, "arr[")?;
+                f.write_str("arr[")?;
                 for (i, elm) in arr.iter().enumerate() {
                     self.print_expr(f, elm)?;
 
                     if i != arr.len() - 1 {
-                        write!(f, ", ")?;
+                        f.write_str(", ")?;
                     }
                 }
-                write!(f, "]")
+                f.write_str("]")
             }
 
             Expression::Tuple(tup) => {
-                write!(f, "tup[")?;
+                f.write_str("tup[")?;
                 for (i, elm) in tup.iter().enumerate() {
                     self.print_expr(f, elm)?;
 
                     if i != tup.len() - 1 {
-                        write!(f, ", ")?;
+                        f.write_str(", ")?;
                     }
                 }
-                write!(f, "]")
+                f.write_str("]")
             }
 
             Expression::Assignment(left, ty, right) => {
                 self.print_expr(f, left)?;
                 match ty {
-                    AssignmentType::Normal => write!(f, " := "),
+                    AssignmentType::Normal => f.write_str(" := "),
                     AssignmentType::BinaryOp(op) => write!(
                         f,
                         " {}= ",
@@ -556,7 +556,7 @@ impl<'expr, 'stmt> PrettyPrinter {
 
             Expression::Range(start, end) => {
                 self.print_expr(f, start)?;
-                write!(f, "..")?;
+                f.write_str("..")?;
                 self.print_expr(f, end)
             }
         }
@@ -569,15 +569,15 @@ impl<'expr, 'stmt> PrettyPrinter {
             Literal::String(s) => write!(f, "{:?}", s),
             Literal::Rune(r) => write!(f, "'{}'", r),
             Literal::Array(arr) => {
-                write!(f, "[")?;
+                f.write_str("[")?;
                 for (i, elm) in arr.iter().enumerate() {
                     self.print_literal(f, elm)?;
 
                     if i != arr.len() - 1 {
-                        write!(f, ", ")?;
+                        f.write_str(", ")?;
                     }
                 }
-                write!(f, "]")
+                f.write_str("]")
             }
             Literal::Float(fl) => write!(f, "{}", fl),
         }
@@ -585,12 +585,12 @@ impl<'expr, 'stmt> PrettyPrinter {
 
     fn print_ty(&mut self, f: &mut dyn Write, ty: &Type) -> Result {
         match ty {
-            Type::Infer => write!(f, "infer"),
+            Type::Infer => f.write_str("infer"),
             Type::Not(ty) => self.print_ty(f, ty.data()),
             Type::Parenthesised(ty) => {
-                write!(f, "(")?;
+                f.write_str("(")?;
                 self.print_ty(f, ty.data())?;
-                write!(f, ")")
+                f.write_str(")")
             }
             Type::Const(ident, ty) => {
                 write!(f, "const {}: ", self.interner.resolve(ident))?;
@@ -602,29 +602,29 @@ impl<'expr, 'stmt> PrettyPrinter {
                 self.print_ty(f, right.data())
             }
             Type::Function { params, returns } => {
-                write!(f, "fn(")?;
+                f.write_str("fn(")?;
                 for (i, param) in params.iter().enumerate() {
                     self.print_ty(f, param.data())?;
 
                     if i != params.len() - 1 {
-                        write!(f, ", ")?;
+                        f.write_str(", ")?;
                     }
                 }
-                write!(f, ") -> ")?;
+                f.write_str(") -> ")?;
                 self.print_ty(f, returns.data())
             }
             Type::TraitObj(traits) => {
                 if traits.is_empty() {
-                    write!(f, "type")
+                    f.write_str("type")
                 } else {
-                    write!(f, "type[")?;
+                    f.write_str("type[")?;
                     for (i, ty) in traits.iter().enumerate() {
                         self.print_ty(f, ty.data())?;
                         if i != traits.len() - 1 {
-                            write!(f, ", ")?;
+                            f.write_str(", ")?;
                         }
                     }
-                    write!(f, "]")
+                    f.write_str("]")
                 }
             }
             Type::Bounded { path, bounds } => {
@@ -640,10 +640,10 @@ impl<'expr, 'stmt> PrettyPrinter {
                     self.print_ty(f, ty.data())?;
 
                     if i != bounds.len() - 1 {
-                        write!(f, ", ")?;
+                        f.write_str(", ")?;
                     }
                 }
-                write!(f, "]")
+                f.write_str("]")
             }
             Type::Integer { sign, width } => write!(
                 f,
@@ -671,31 +671,31 @@ impl<'expr, 'stmt> PrettyPrinter {
                 },
             ),
             Type::Float { width } => write!(f, "f{}", width),
-            Type::Boolean => write!(f, "bool"),
-            Type::String => write!(f, "str"),
-            Type::Rune => write!(f, "rune"),
-            Type::Unit => write!(f, "unit"),
-            Type::Absurd => write!(f, "absurd"),
+            Type::Boolean => f.write_str("bool"),
+            Type::String => f.write_str("str"),
+            Type::Rune => f.write_str("rune"),
+            Type::Unit => f.write_str("unit"),
+            Type::Absurd => f.write_str("absurd"),
             Type::Array(len, ty) => {
                 write!(f, "arr[{}, ", len)?;
                 self.print_ty(f, ty.data())?;
-                write!(f, "]")
+                f.write_str("]")
             }
             Type::Slice(ty) => {
-                write!(f, "arr[")?;
+                f.write_str("arr[")?;
                 self.print_ty(f, ty.data())?;
-                write!(f, "]")
+                f.write_str("]")
             }
             Type::Tuple(types) => {
-                write!(f, "tup[")?;
+                f.write_str("tup[")?;
                 for (i, ty) in types.iter().enumerate() {
                     self.print_ty(f, ty.data())?;
 
                     if i != types.len() - 1 {
-                        write!(f, ", ")?;
+                        f.write_str(", ")?;
                     }
                 }
-                write!(f, "]")
+                f.write_str("]")
             }
             Type::ItemPath(path) => write!(
                 f,
@@ -711,11 +711,11 @@ impl<'expr, 'stmt> PrettyPrinter {
     fn print_attr(&mut self, f: &mut dyn Write, attr: Attribute) -> Result {
         match attr {
             Attribute::Visibility(vis) => match vis {
-                Visibility::Exposed => write!(f, "exposed "),
-                Visibility::Package => write!(f, "pkg "),
-                Visibility::FileLocal => write!(f, ""),
+                Visibility::Exposed => f.write_str("exposed "),
+                Visibility::Package => f.write_str("pkg "),
+                Visibility::FileLocal => f.write_str(""),
             },
-            Attribute::Const => write!(f, "const "),
+            Attribute::Const => f.write_str("const "),
         }
     }
 
@@ -734,7 +734,7 @@ impl<'expr, 'stmt> PrettyPrinter {
 
             Statement::Return(ret) => {
                 if let Some(ret) = ret {
-                    write!(f, "return ")?;
+                    f.write_str("return ")?;
                     self.print_expr(f, ret)?;
                     writeln!(f)
                 } else {
@@ -744,7 +744,7 @@ impl<'expr, 'stmt> PrettyPrinter {
 
             Statement::Break(brk) => {
                 if let Some(brk) = brk {
-                    write!(f, "break ")?;
+                    f.write_str("break ")?;
                     self.print_expr(f, brk)?;
                     writeln!(f)
                 } else {
@@ -782,7 +782,7 @@ impl<'expr, 'stmt> PrettyPrinter {
                 then,
                 else_clause,
             } => {
-                write!(f, "while ")?;
+                f.write_str("while ")?;
                 self.print_expr(f, condition)?;
                 writeln!(f)?;
 
@@ -825,9 +825,9 @@ impl<'expr, 'stmt> PrettyPrinter {
                 then,
                 else_clause,
             } => {
-                write!(f, "for ")?;
+                f.write_str("for ")?;
                 self.print_expr(f, var)?;
-                write!(f, " in ")?;
+                f.write_str(" in ")?;
                 self.print_expr(f, condition)?;
                 writeln!(f)?;
 
@@ -878,7 +878,7 @@ impl<'expr, 'stmt> PrettyPrinter {
                     self.interner.resolve(name)
                 )?;
                 self.print_ty(f, ty.data())?;
-                write!(f, " := ")?;
+                f.write_str(" := ")?;
                 self.print_expr(f, val)?;
                 writeln!(f)
             }
@@ -889,7 +889,7 @@ impl<'expr, 'stmt> PrettyPrinter {
                 clauses,
                 else_clause,
             } => {
-                write!(f, "if ")?;
+                f.write_str("if ")?;
                 self.print_expr(f, condition)?;
                 writeln!(f)?;
 
@@ -901,7 +901,7 @@ impl<'expr, 'stmt> PrettyPrinter {
 
                 for (cond, body) in clauses {
                     self.print_indent(f)?;
-                    write!(f, "else if ")?;
+                    f.write_str("else if ")?;
                     self.print_expr(f, cond)?;
                     writeln!(f)?;
 
@@ -914,7 +914,7 @@ impl<'expr, 'stmt> PrettyPrinter {
 
                 self.print_indent(f)?;
                 if let Some(body) = else_clause {
-                    write!(f, "else ")?;
+                    f.write_str("else ")?;
 
                     self.indent_level += 1;
                     for stmt in body {
@@ -929,7 +929,7 @@ impl<'expr, 'stmt> PrettyPrinter {
             }
 
             Statement::Match { var, arms } => {
-                write!(f, "match ")?;
+                f.write_str("match ")?;
                 self.print_expr(f, var)?;
                 writeln!(f)?;
 
@@ -939,9 +939,9 @@ impl<'expr, 'stmt> PrettyPrinter {
 
                     self.print_binding(f, binding)?;
                     if let Some(whre) = whre {
-                        write!(f, "where ")?;
+                        f.write_str("where ")?;
                         self.print_expr(f, whre)?;
-                        write!(f, " ")?;
+                        f.write_str(" ")?;
                     }
                     writeln!(f, "=>")?;
 

--- a/crates/crunch-parser/src/pretty_printer.rs
+++ b/crates/crunch-parser/src/pretty_printer.rs
@@ -760,16 +760,16 @@ impl<'expr, 'stmt> PrettyPrinter {
                     self.print_stmt(f, stmt)?
                 }
                 self.indent_level -= 1;
-                
+
                 if let Some(else_clause) = else_clause {
-                     self.print_indent(f)?;
-                     writeln!(f, "else")?;
-                     
-                     self.indent_level += 1;
-                     for stmt in else_clause {
-                         self.print_stmt(f, stmt)?
-                     }
-                     self.indent_level -= 1;
+                    self.print_indent(f)?;
+                    writeln!(f, "else")?;
+
+                    self.indent_level += 1;
+                    for stmt in else_clause {
+                        self.print_stmt(f, stmt)?
+                    }
+                    self.indent_level -= 1;
                 }
 
                 self.print_indent(f)?;
@@ -802,16 +802,16 @@ impl<'expr, 'stmt> PrettyPrinter {
                     }
                     self.indent_level -= 1;
                 }
-                
+
                 if let Some(else_clause) = else_clause {
-                     self.print_indent(f)?;
-                     writeln!(f, "else")?;
-                     
-                     self.indent_level += 1;
-                     for stmt in else_clause {
-                         self.print_stmt(f, stmt)?
-                     }
-                     self.indent_level -= 1;
+                    self.print_indent(f)?;
+                    writeln!(f, "else")?;
+
+                    self.indent_level += 1;
+                    for stmt in else_clause {
+                        self.print_stmt(f, stmt)?
+                    }
+                    self.indent_level -= 1;
                 }
 
                 self.print_indent(f)?;
@@ -847,16 +847,16 @@ impl<'expr, 'stmt> PrettyPrinter {
                     }
                     self.indent_level -= 1;
                 }
-                
+
                 if let Some(else_clause) = else_clause {
-                     self.print_indent(f)?;
-                     writeln!(f, "else")?;
-                     
-                     self.indent_level += 1;
-                     for stmt in else_clause {
-                         self.print_stmt(f, stmt)?
-                     }
-                     self.indent_level -= 1;
+                    self.print_indent(f)?;
+                    writeln!(f, "else")?;
+
+                    self.indent_level += 1;
+                    for stmt in else_clause {
+                        self.print_stmt(f, stmt)?
+                    }
+                    self.indent_level -= 1;
                 }
 
                 self.print_indent(f)?;

--- a/crates/crunch-parser/src/pretty_printer.rs
+++ b/crates/crunch-parser/src/pretty_printer.rs
@@ -732,24 +732,20 @@ impl<'expr, 'stmt> PrettyPrinter {
 
             Statement::Continue => writeln!(f, "continue"),
 
-            Statement::Return(ret) => {
-                if let Some(ret) = ret {
-                    f.write_str("return ")?;
-                    self.print_expr(f, ret)?;
-                    writeln!(f)
-                } else {
-                    writeln!(f, "return")
-                }
+            Statement::Return(None) => writeln!(f, "return"),
+
+            Statement::Return(Some(ret)) => {
+                f.write_str("return ")?;
+                self.print_expr(f, ret)?;
+                writeln!(f)
             }
 
-            Statement::Break(brk) => {
-                if let Some(brk) = brk {
-                    f.write_str("break ")?;
-                    self.print_expr(f, brk)?;
-                    writeln!(f)
-                } else {
-                    writeln!(f, "break")
-                }
+            Statement::Break(None) => writeln!(f, "break"),
+
+            Statement::Break(Some(brk)) => {
+                f.write_str("break ")?;
+                self.print_expr(f, brk)?;
+                writeln!(f)
             }
 
             Statement::Loop { body, else_clause } => {

--- a/crates/crunch-parser/src/pretty_printer.rs
+++ b/crates/crunch-parser/src/pretty_printer.rs
@@ -752,7 +752,7 @@ impl<'expr, 'stmt> PrettyPrinter {
                 }
             }
 
-            Statement::Loop { body, then } => {
+            Statement::Loop(body) => {
                 writeln!(f, "loop")?;
 
                 self.indent_level += 1;
@@ -760,17 +760,6 @@ impl<'expr, 'stmt> PrettyPrinter {
                     self.print_stmt(f, stmt)?
                 }
                 self.indent_level -= 1;
-
-                if let Some(then) = then {
-                    self.print_indent(f)?;
-                    writeln!(f, "then")?;
-
-                    self.indent_level += 1;
-                    for stmt in then {
-                        self.print_stmt(f, stmt)?
-                    }
-                    self.indent_level -= 1;
-                }
 
                 self.print_indent(f)?;
                 writeln!(f, "end")

--- a/crates/crunch-parser/src/symbol_table.rs
+++ b/crates/crunch-parser/src/symbol_table.rs
@@ -369,21 +369,12 @@ impl Graph<Scope, MaybeSym> {
                 }
             }
 
-            Statement::Loop { body, then } => {
+            Statement::Loop(body) => {
                 let body_scope = self.push(Scope::new());
                 self.add_child(parent, body_scope).unwrap();
 
                 for stmt in body {
                     self.push_stmt(parent, stmt);
-                }
-
-                if let Some(then) = then {
-                    let then_scope = self.push(Scope::new());
-                    self.add_child(parent, then_scope).unwrap();
-
-                    for stmt in then {
-                        self.push_stmt(parent, stmt);
-                    }
                 }
             }
 

--- a/crates/crunch-parser/src/symbol_table.rs
+++ b/crates/crunch-parser/src/symbol_table.rs
@@ -349,6 +349,7 @@ impl Graph<Scope, MaybeSym> {
                 condition,
                 body,
                 then,
+                else_clause,
             } => {
                 self.push_expr(parent, condition);
 
@@ -367,15 +368,33 @@ impl Graph<Scope, MaybeSym> {
                         self.push_stmt(parent, &*stmt);
                     }
                 }
+
+                if let Some(else_clause) = else_clause {
+                     let else_scope = self.push(Scope::new());
+                     self.add_child(parent, else_scope).unwrap();
+
+                     for stmt in else_clause {
+                         self.push_stmt(parent, stmt);
+                     }
+                 }
             }
 
-            Statement::Loop(body) => {
+            Statement::Loop { body, else_clause } => {
                 let body_scope = self.push(Scope::new());
                 self.add_child(parent, body_scope).unwrap();
 
                 for stmt in body {
                     self.push_stmt(parent, stmt);
                 }
+
+                if let Some(else_clause) = else_clause {
+                     let else_scope = self.push(Scope::new());
+                     self.add_child(parent, else_scope).unwrap();
+
+                     for stmt in else_clause {
+                         self.push_stmt(parent, stmt);
+                     }
+                 }
             }
 
             Statement::For {
@@ -383,6 +402,7 @@ impl Graph<Scope, MaybeSym> {
                 condition,
                 body,
                 then,
+                else_clause,
             } => {
                 self.push_expr(parent, var);
                 self.push_expr(parent, condition);
@@ -402,6 +422,15 @@ impl Graph<Scope, MaybeSym> {
                         self.push_stmt(parent, &*stmt);
                     }
                 }
+
+                if let Some(else_clause) = else_clause {
+                     let else_scope = self.push(Scope::new());
+                     self.add_child(parent, else_scope).unwrap();
+
+                     for stmt in else_clause {
+                         self.push_stmt(parent, stmt);
+                     }
+                 }
             }
 
             Statement::Match { var, arms } => {

--- a/crates/crunch-parser/src/symbol_table.rs
+++ b/crates/crunch-parser/src/symbol_table.rs
@@ -370,13 +370,13 @@ impl Graph<Scope, MaybeSym> {
                 }
 
                 if let Some(else_clause) = else_clause {
-                     let else_scope = self.push(Scope::new());
-                     self.add_child(parent, else_scope).unwrap();
+                    let else_scope = self.push(Scope::new());
+                    self.add_child(parent, else_scope).unwrap();
 
-                     for stmt in else_clause {
-                         self.push_stmt(parent, stmt);
-                     }
-                 }
+                    for stmt in else_clause {
+                        self.push_stmt(parent, stmt);
+                    }
+                }
             }
 
             Statement::Loop { body, else_clause } => {
@@ -388,13 +388,13 @@ impl Graph<Scope, MaybeSym> {
                 }
 
                 if let Some(else_clause) = else_clause {
-                     let else_scope = self.push(Scope::new());
-                     self.add_child(parent, else_scope).unwrap();
+                    let else_scope = self.push(Scope::new());
+                    self.add_child(parent, else_scope).unwrap();
 
-                     for stmt in else_clause {
-                         self.push_stmt(parent, stmt);
-                     }
-                 }
+                    for stmt in else_clause {
+                        self.push_stmt(parent, stmt);
+                    }
+                }
             }
 
             Statement::For {
@@ -424,13 +424,13 @@ impl Graph<Scope, MaybeSym> {
                 }
 
                 if let Some(else_clause) = else_clause {
-                     let else_scope = self.push(Scope::new());
-                     self.add_child(parent, else_scope).unwrap();
+                    let else_scope = self.push(Scope::new());
+                    self.add_child(parent, else_scope).unwrap();
 
-                     for stmt in else_clause {
-                         self.push_stmt(parent, stmt);
-                     }
-                 }
+                    for stmt in else_clause {
+                        self.push_stmt(parent, stmt);
+                    }
+                }
             }
 
             Statement::Match { var, arms } => {

--- a/crates/ladder/src/lib.rs
+++ b/crates/ladder/src/lib.rs
@@ -194,13 +194,11 @@ impl Ladder {
                 }
             }
 
-            AstStmt::Loop { body, _else_clause } => {
-                Stmt::Loop(
-                    body.iter()
-                        .filter_map(|stmt| self.lower_statement(stmt))
-                        .collect(),
-                )
-            }
+            AstStmt::Loop { body, _else_clause } => Stmt::Loop(
+                body.iter()
+                    .filter_map(|stmt| self.lower_statement(stmt))
+                    .collect(),
+            ),
 
             AstStmt::Empty => return None,
 

--- a/crates/ladder/src/lib.rs
+++ b/crates/ladder/src/lib.rs
@@ -194,7 +194,10 @@ impl Ladder {
                 }
             }
 
-            AstStmt::Loop { body, _else_clause } => Stmt::Loop(
+            AstStmt::Loop {
+                body,
+                else_clause: _else,
+            } => Stmt::Loop(
                 body.iter()
                     .filter_map(|stmt| self.lower_statement(stmt))
                     .collect(),

--- a/crates/ladder/src/lib.rs
+++ b/crates/ladder/src/lib.rs
@@ -194,8 +194,7 @@ impl Ladder {
                 }
             }
 
-            AstStmt::Loop { body, then: _then } => {
-                // TODO: Why in hell do `loop`s have `then`s?
+            AstStmt::Loop { body, _else_clause } => {
                 Stmt::Loop(
                     body.iter()
                         .filter_map(|stmt| self.lower_statement(stmt))


### PR DESCRIPTION
+ removed `then` from `loop` statement
+ added `else` clause to all loop statements
+ replaced some instances of `write!(f, "x")` with `f.write_str("x")` to reduce time on macro expansion